### PR TITLE
Add CloudFormation deployment to deployment docs

### DIFF
--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -118,6 +118,25 @@ python manage.py collectstatic
 ```
 You might want to use something like Supervisor to keep this command running
 
+# AWS ECS Fargate
+We maintain a CloudFormation [config](https://github.com/fuziontech/posthog/blob/master/deployment/aws/ecs/combined.yaml) for deploying Posthog with Redis and Postgres to a stack on AWS. For the container hosting we use fargate so that you only pay for what you need.
+
+For an in depth how-to on CloudFormations check out the [AWS Docs](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/GettingStarted.Walkthrough.html)
+
+The gist is this though:
+1. Grab YAML Configs from [here](https://github.com/fuziontech/posthog/blob/master/deployment/aws/ecs/combined.yaml)
+2. Go to the CloudFormation page on your AWS [console](https://console.aws.amazon.com/cloudformation/)
+3. Click Create `Stack -> With New Resources (standard)`
+4. Select Upload a template and link to your newly downloaded YAML config
+5. Choose a Stack Name and review the Parameters. You will need to update these if you want to modify default behaviours or setup SMTP configs as described below
+6. Review the rest of the config wizard pages
+7. On the Review stack page you can click `estimate cost` to get an estimate of how much your specific config will cost per month. The default configs cost about ~$27 USD a month
+8. If you are ready, click `Create Stack`!
+9. Once deployment completes look under `Options` for the Publicly facing ELB Host
+10. 🎉🎉 Enjoy Posthog 🎉🎉
+
+!> You should review all of the parameters in the config and also you should _definitely_ setup for TLS. Once you have TLS setup for your ELB you should disable insecure access via HTTP by removing the evironment variable `DISABLE_SECURE_SSL_REDIRECT=1` from the Task definition in ECS and deploy the updated Task definition revision.
+
 # Restrict access by IP
 
 You can restrict access to PostHog by IP by passing `ALLOWED_IP_BLOCKS`. This is a comma separated list, and can either be individual IP addresses or subnets. For example:

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -123,7 +123,7 @@ We maintain a CloudFormation [config](https://github.com/fuziontech/posthog/blob
 
 For an in depth how-to on CloudFormations check out the [AWS Docs](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/GettingStarted.Walkthrough.html)
 
-The gist is this though:
+The gist is this:
 1. Grab YAML Configs from [here](https://github.com/fuziontech/posthog/blob/master/deployment/aws/ecs/combined.yaml)
 2. Go to the CloudFormation page on your AWS [console](https://console.aws.amazon.com/cloudformation/)
 3. Click Create `Stack -> With New Resources (standard)`


### PR DESCRIPTION
Add another option for users to deploy Posthog into their infrastructure. This time using AWS, ECS, Fargate, Elasticache, and RDS all with a parameterized CloudWatch config.

One thing to do _before_ this lands:
1. We need a better story for where the config itself will live (outside of my fork of posthog) probably on S3 somewhere

A few things to do sometime in the future:
1. A Deployment artifact repo for similar configs like this. I could definitely see users wanting to share their other configs like Terraform or Ansible configs
2. Some way to automatically push the config from repo to s3 whenever it is updated